### PR TITLE
fix: support dual mode in commands file

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1,4 +1,4 @@
-const { getByCommand } = require('./src/get-by')
+const { registerCommand } = require('./src')
 
 // register a new custom command cy.getByLabel
-Cypress.Commands.add('getByLabel', getByCommand('getByLabel'))
+registerCommand ();


### PR DESCRIPTION
in the current state, using `import 'cypress-get-by-label/commands'` does not allow to use chaining as child command